### PR TITLE
Adds specs2 matchers for result

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ List is as follows:
   with no dependencies for the JVM.
 - [result](result/): a right biased union type that holds a value
   for a successful computation or a value for a failed one.
+- [result-specs2](result-specs2/): specs2 matchers for the result type
 
 ## Why?
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,10 @@ scalacOptions in ThisBuild ++= Seq(
   "-feature")
 
 lazy val root = (project in file(".")).
-  aggregate(i18n, result)
+  aggregate(i18n, result, resultSpecs2)
 
 lazy val i18n = project
 
 lazy val result = project
+
+lazy val resultSpecs2 = (project in file("result-specs2")).dependsOn(result)

--- a/result-specs2/README.md
+++ b/result-specs2/README.md
@@ -1,0 +1,5 @@
+# Result Specs2 Matchers [![bintray](https://api.bintray.com/packages/albertpastrana/maven/uscala-result-specs2/images/download.svg) ](https://bintray.com/albertpastrana/maven/uscala-result-specs2/_latestVersion)
+
+A set of specs2 matchers for the μscala `Result` type.
+
+Allows users to test for Ok or Failure result types from functions returning a `Result`.

--- a/result-specs2/build.sbt
+++ b/result-specs2/build.sbt
@@ -1,0 +1,17 @@
+import sbt.Keys._
+import sbt._
+
+name := "uscala-result-specs2"
+organization := "org.uscala"
+description := "Specs2 matchers for uscala result."
+licenses += "MIT" -> url("https://opensource.org/licenses/MIT")
+homepage := Some(url("https://github.com/albertpastrana/uscala/tree/master/result"))
+developers := List(
+  Developer(id = "albertpastrana", name = "Albert Pastrana", email = "", url = new URL("https://albertpastrana.com"))
+)
+scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/uscala/tree/master/result"),
+                        connection = "scm:git:git@github.com:albertpastrana/uscala.git"))
+
+libraryDependencies ++= Seq(
+  "org.specs2" %% "specs2-core" % "3.8.3"
+)

--- a/result-specs2/build.sbt
+++ b/result-specs2/build.sbt
@@ -7,7 +7,8 @@ description := "Specs2 matchers for uscala result."
 licenses += "MIT" -> url("https://opensource.org/licenses/MIT")
 homepage := Some(url("https://github.com/albertpastrana/uscala/tree/master/result"))
 developers := List(
-  Developer(id = "albertpastrana", name = "Albert Pastrana", email = "", url = new URL("https://albertpastrana.com"))
+  Developer(id = "albertpastrana", name = "Albert Pastrana", email = "", url = new URL("https://albertpastrana.com")),
+  Developer(id = "janstenpickle", name = "Chris Jansen", email = "", url = new URL("http://nic-cage.xyz"))
 )
 scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/uscala/tree/master/result"),
                         connection = "scm:git:git@github.com:albertpastrana/uscala.git"))

--- a/result-specs2/src/main/scala/uscala/result/specs2/ResultMatchers.scala
+++ b/result-specs2/src/main/scala/uscala/result/specs2/ResultMatchers.scala
@@ -1,0 +1,20 @@
+package uscala.result.specs2
+
+import org.specs2.matcher.{OptionLikeCheckedMatcher, OptionLikeMatcher, ValueCheck}
+import uscala.result.Result
+
+trait ResultMatchers {
+  def beOk[T](t: ValueCheck[T]) = OkValidationCheckedMatcher(t)
+  def beOk[T] = OkValidationMatcher[T]()
+
+  def beFail[T](t: ValueCheck[T]) = FailValidationCheckedMatcher(t)
+  def beFail[T] = FailValidationMatcher[T]()
+}
+
+object ResultMatchers extends ResultMatchers
+
+case class OkValidationMatcher[T]() extends OptionLikeMatcher[({type l[a]=Result[_, a]})#l, T, T]("Ok", _.toOption)
+case class OkValidationCheckedMatcher[T](check: ValueCheck[T]) extends OptionLikeCheckedMatcher[({type l[a]=Result[_, a]})#l, T, T]("Ok", _.toOption, check)
+
+case class FailValidationMatcher[T]() extends OptionLikeMatcher[({type l[a]=Result[a, _]})#l, T, T]("Fail", _.toEither.left.toOption)
+case class FailValidationCheckedMatcher[T](check: ValueCheck[T]) extends OptionLikeCheckedMatcher[({type l[a]=Result[a, _]})#l, T, T]("Fail", _.toEither.left.toOption, check)

--- a/result-specs2/src/test/scala/uscala/result/specs2/ResultMatchersSpec.scala
+++ b/result-specs2/src/test/scala/uscala/result/specs2/ResultMatchersSpec.scala
@@ -1,0 +1,23 @@
+package uscala.result.specs2
+
+import org.specs2.Spec
+import org.specs2.matcher.{ResultMatchers => SResultMatchers}
+import uscala.result.Result._
+
+class ResultMatchersSpec extends Spec with SResultMatchers with ResultMatchers { def is = s2"""
+ The ResultMatchers trait provides matchers to check Result instances
+
+  beOk checks if an element is Ok(_)
+  ${ Ok(1) must beOk(1) }
+  ${ Ok(1) must beOk((i: Int) => i must be_>(0)) }
+  ${ Ok(1) must beOk(Seq(true, true)) }
+  ${ Ok(1) must beOk(===(1)) }
+  ${ Ok(Seq(1)) must beOk(===(Seq(1))) }
+  ${ Ok(1) must beOk.like { case i => i must be_>(0) } }
+  ${ (Ok(1) must beOk.like { case i => i must be_<(0) }) returns "'Ok(1)' is Ok but 1 is not less than 0" }
+  beFail checks if an element is Fail(_)
+  ${ Fail(1) must beFail(1) }
+  ${ Fail(1) must beFail(===(1)) }
+  ${ Fail(1) must beFail.like { case i => i must be_>(0) } } """
+
+}


### PR DESCRIPTION
This follows the same pattern as specs2 scalaz matchers for disjunction and validation

What do you think of the options? `beOk` and `beFail` I've tried to make them match the syntax of result.
