### PR TITLE
Async result type for results inside of futures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,4 +34,4 @@ lazy val result = project
 
 lazy val resultSpecs2 = (project in file("result-specs2")).dependsOn(result)
 
-lazy val resultAsync = (project in file("result-async")).dependsOn(result)
+lazy val resultAsync = (project in file("result-async")).dependsOn(result, resultSpecs2 % "test->compile")

--- a/build.sbt
+++ b/build.sbt
@@ -26,10 +26,12 @@ scalacOptions in ThisBuild ++= Seq(
   "-feature")
 
 lazy val root = (project in file(".")).
-  aggregate(i18n, result, resultSpecs2)
+  aggregate(i18n, result, resultSpecs2, resultAsync)
 
 lazy val i18n = project
 
 lazy val result = project
 
 lazy val resultSpecs2 = (project in file("result-specs2")).dependsOn(result)
+
+lazy val resultAsync = (project in file("result-async")).dependsOn(result)

--- a/result-async/build.sbt
+++ b/result-async/build.sbt
@@ -1,0 +1,19 @@
+import sbt.Keys._
+import sbt._
+
+name := "uscala-result-async"
+organization := "org.uscala"
+description := "A right biased union type that holds a value for a successful computation or a value for a failed one."
+licenses += "MIT" -> url("https://opensource.org/licenses/MIT")
+homepage := Some(url("https://github.com/albertpastrana/uscala/tree/master/result"))
+developers := List(
+  Developer(id = "albertpastrana", name = "Albert Pastrana", email = "", url = new URL("https://albertpastrana.com")),
+  Developer(id = "janstenpickle", name = "Chris Jansen", email = "", url = new URL("http://nic-cage.xyz"))
+)
+scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/uscala/tree/master/result"),
+                        connection = "scm:git:git@github.com:albertpastrana/uscala.git"))
+
+libraryDependencies ++= Seq(
+  "org.specs2" %% "specs2-core" % "3.8.3" % "test",
+  "org.specs2" %% "specs2-scalacheck" % "3.8.3" % "test"
+)

--- a/result-async/src/main/scala/uscala/result/async/AsyncResult.scala
+++ b/result-async/src/main/scala/uscala/result/async/AsyncResult.scala
@@ -1,0 +1,89 @@
+package uscala.result.async
+
+import uscala.result.Result
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.Try
+
+final case class AsyncResult[+A, +B](underlying: Future[Result[A, B]]) {
+  def flatMap[AA >: A, D](f: B => AsyncResult[AA, D])(implicit ec: ExecutionContext): AsyncResult[AA, D] =
+    AsyncResult(
+      map(f).underlying.flatMap(
+        _.fold(
+          err => Future(Result.fail(err)),
+          _.underlying
+        )
+      )
+    )
+
+  def flatMapR[AA >: A, D](f: B => Result[AA, D])(implicit ec: ExecutionContext): AsyncResult[AA, D] =
+    AsyncResult(
+      underlying.map(
+        _.flatMap(f)
+      )
+    )
+
+
+  def flatMapF[C](f: B => Future[C])(implicit ec: ExecutionContext): AsyncResult[A, C] =
+    AsyncResult(
+      underlying.flatMap(
+        _.fold(
+          err => Future(Result.fail(err)),
+          f(_).map(Result.ok)
+        )
+      )
+    )
+
+  def map[C](f: B => C)(implicit ec: ExecutionContext): AsyncResult[A, C] =
+    AsyncResult(
+      underlying.map(
+        _.map(f)
+      )
+    )
+
+  def mapOk[C](f: B => C)(implicit ec: ExecutionContext): AsyncResult[A, C] = map(f)
+
+  def leftMap[C](f: A => C)(implicit ec: ExecutionContext): AsyncResult[C, B] =
+    AsyncResult(
+      underlying.map(
+        _.leftMap(f)
+      )
+    )
+
+  def mapFail[C](f: A => C)(implicit ec: ExecutionContext): AsyncResult[C, B] = leftMap(f)
+
+  def bimap[C, D](fa: A => C, fb: B => D)(implicit ec: ExecutionContext): AsyncResult[C, D] =
+    AsyncResult(
+      underlying.map(
+        _.bimap(fa, fb)
+      )
+    )
+
+  def swap(implicit ec: ExecutionContext): AsyncResult[B, A] = AsyncResult(
+    underlying.map(
+      _.swap
+    )
+  )
+
+  def fold[C](fa: A => C, fb: B => C)(implicit ec: ExecutionContext): Future[C] = underlying.map(_.fold(fa, fb))
+
+  def attemptRun[AA >: A](implicit f: Throwable => AA, ec: ExecutionContext): Result[AA, B] =
+    Result.fromTry(
+      Try(Await.result(underlying, Duration.Inf))
+    ).leftMap(f).flatMap(identity)
+}
+
+object AsyncResult {
+
+  def fromFuture[A, B](f: Future[B])(implicit ex: ExecutionContext): AsyncResult[A, B] = AsyncResult(f.map(Result.ok))
+
+  def fromResult[A, B](r: Result[A, B])(implicit ex: ExecutionContext): AsyncResult[A, B] = AsyncResult(Future(r))
+
+  def now[A, B](b: B)(implicit ex: ExecutionContext): AsyncResult[A, B] = AsyncResult(Future(Result.ok(b)))
+
+  def ok[A, B](b: B)(implicit ex: ExecutionContext): AsyncResult[A, B] = now(b)
+
+  def fail[A, B](a: A)(implicit ex: ExecutionContext): AsyncResult[A, B] = AsyncResult(Future(Result.fail(a)))
+
+}

--- a/result-async/src/test/scala/uscala/concurrent/result/AsyncResultSpec.scala
+++ b/result-async/src/test/scala/uscala/concurrent/result/AsyncResultSpec.scala
@@ -1,0 +1,205 @@
+package uscala.concurrent.result
+
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+import uscala.result.Result
+import uscala.result.Result.{Fail, Ok}
+import uscala.result.specs2.ResultMatchers
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.{Duration, _}
+import scala.concurrent.{Await, Future}
+
+class AsyncResultSpec extends Specification with ScalaCheck with ResultMatchers {
+
+  def resultGen: Gen[Result[Int, Int]] = for {
+    i <- Gen.posNum[Int]
+    res <- Gen.oneOf(Ok[Int](_), Fail[Int](_))
+  } yield res(i)
+
+  implicit def arbResult: Arbitrary[Result[Int, Int]] = Arbitrary(resultGen)
+
+  def f(n: Int) = n + 1
+  def fa(n: Int) = f(n)
+  def fb(n: Int) = n + 2
+
+  def attempt[A, B](a: AsyncResult[A, B]): Result[A, B] = attempt(a.underlying)
+  def attempt[T](f: Future[T]): T = Await.result(f, Duration.Inf)
+
+  "fold" >> {
+    "should apply fa if the result is Fail" >> prop { n: Int =>
+      attempt(AsyncResult.fail(n).fold(fa, fb)) must_=== fa(n)
+    }
+    "should apply fb if the result is Ok" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).fold(fa, fb)) must_=== fb(n)
+    }
+  }
+
+  "map" >> {
+    "should not apply f if the result is Fail" >> prop { n: Int =>
+      def a(i: Int) = i.toString
+      val b: AsyncResult[Throwable, Int] = AsyncResult.ok(1)
+      val c: AsyncResult[Throwable, String] = b.map(a)
+      val d: AsyncResult[Throwable, Int] = c.map(x=>x.toInt)
+      attempt(AsyncResult.fail(n).map(f)) must_=== Fail(n)
+    }
+    "should apply f if the result is Ok" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).map(f)) must_=== Ok(f(n))
+    }
+  }
+
+  "leftMap" >> {
+    "should apply f if the result is Fail" >> prop { n: Int =>
+      attempt(AsyncResult.fail(n).leftMap(f)) must_=== Fail(f(n))
+    }
+    "should not apply f if the result is Ok" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).leftMap(f)) must_=== Ok(n)
+    }
+  }
+
+  "mapOk" >> {
+    "should be an alias of map" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).mapOk(f)) must_=== Ok(n).map(f)
+      attempt(AsyncResult.fail(n).mapOk(f)) must_=== Fail(n).map(f)
+    }
+  }
+
+  "mapFail" >> {
+    "should be an alias of leftMap" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).mapFail(f)) must_=== Ok(n).leftMap(f)
+      attempt(AsyncResult.fail(n).mapFail(f)) must_=== Fail(n).leftMap(f)
+    }
+  }
+
+  "flatMap" >> {
+    def fa(a: Int): AsyncResult[Int, Int] = if (a % 2 == 0) AsyncResult.ok(a) else AsyncResult.fail(a)
+    def fb(a: Int): AsyncResult[Int, Int] = if (a % 3 == 0) AsyncResult.ok(a) else AsyncResult.fail(a)
+    def fc(a: Int): AsyncResult[Int, Int] = if (a % 5 == 0) AsyncResult.ok(a) else AsyncResult.fail(a)
+    "should not apply fa if the result is Fail" >> prop { n: Int =>
+      attempt(AsyncResult.fail(n).flatMap(fa)) must_=== Fail(n)
+    }
+    "should apply fa if the result is Ok" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).flatMap(fa)) must_=== attempt(fa(n))
+    }
+    "should be associative" >> prop { n: Int =>
+      attempt(fa(n).flatMap(fb).flatMap(fc)) must_=== attempt(fa(n).flatMap(x => fb(x).flatMap(fc)))
+    }
+  }
+
+  "flatMapR" >> {
+    def fa(a: Int): Result[Int, Int] = if (a % 2 == 0) Ok(a) else Fail(a)
+    def fb(a: Int): Result[Int, Int] = if (a % 3 == 0) Ok(a) else Fail(a)
+    def fc(a: Int): Result[Int, Int] = if (a % 5 == 0) Ok(a) else Fail(a)
+    "should not apply fa if the result is Fail" >> prop { n: Int =>
+      attempt(AsyncResult.fail(n).flatMapR(fa)) must_=== Fail(n)
+    }
+    "should apply fa if the result is Ok" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).flatMapR(fa)) must_=== fa(n)
+    }
+    "should be associative" >> prop { n: Int =>
+      attempt(AsyncResult.fromResult(fa(n)).flatMapR(fb).flatMapR(fc)) must_=== fa(n).flatMap(x => fb(x).flatMap(fc))
+    }
+  }
+
+  "flatMapF" >> {
+    def fa(a: Int): Future[Int] = Future(a + 1)
+    def fb(a: Int): Future[Int] = Future(a + 2)
+    def fc(a: Int): Future[Int] = Future(a + 3)
+    "should not apply fa if the result is Fail" >> prop { n: Int =>
+      attempt(AsyncResult.fail(n).flatMapF(fa)) must_=== Fail(n)
+    }
+    "should apply fa if the result is Ok" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).flatMapF(fa)).getOrElse(n - 1) must_=== attempt(fa(n))
+    }
+    "should be associative" >> prop { n: Int =>
+      attempt(AsyncResult.fromFuture(fa(n)).flatMapF(fb).flatMapF(fc)).getOrElse(n - 1) must_=== attempt(fa(n).flatMap(x => fb(x).flatMap(fc)))
+    }
+  }
+
+  "bimap" >> {
+    "should apply fa if the result is Fail" >> prop { n: Int =>
+      attempt(AsyncResult.fail(n).bimap(fa, fb)) must_=== Fail(fa(n))
+    }
+    "should apply fb if the result is Ok" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).bimap(fa, fb)) must_=== Ok(fb(n))
+    }
+  }
+
+  "swap" >> {
+    "should move Fail value to Ok" >> prop { n: Int =>
+      attempt(AsyncResult.fail(n).swap) must_=== Ok(n)
+    }
+    "should move Ok value to Fail" >> prop { n: Int =>
+      attempt(AsyncResult.ok(n).swap) must_=== Fail(n)
+    }
+  }
+
+  "attemptRun" >> {
+    "Returns a result after successfully evaluating the future" >> prop { r: Result[Int, Int] =>
+      AsyncResult.fromResult(r).attemptRun must_=== Ok(r)
+    }
+    "Returns a failed result with an exception on the left after failing to evaluate the future" >> prop { s: String =>
+      val e = new RuntimeException(s)
+      AsyncResult.fromFuture(Future.failed(e)).attemptRun must_=== Fail(e)
+    }
+    "Maps an exception from a failed future into the type of the left hand side of the result" >> prop { s: String =>
+      AsyncResult.fromFuture(Future.failed(new RuntimeException(s))).attemptRun(_.getMessage) must_=== Fail(s)
+    }
+  }
+
+  "attemptRunFor" >> {
+    "Returns a result after successfully evaluating the future" >> prop { r: Result[Int, Int] =>
+      AsyncResult.fromResult(r).attemptRunFor(1.millis) must_=== Ok(r)
+    }
+
+    "Fails with an exception on the left of a result when execution times out" >> prop { s: String =>
+      AsyncResult.fromFuture(Future{ Thread.sleep(2000); s }).attemptRunFor(1.millis) must beFail[Throwable].like {
+        case a => a.getMessage must_=== "Futures timed out after [1 millisecond]"
+      }
+    }
+    "Returns a failed result of the underlying result type when execution times out" >> prop { s: String =>
+      AsyncResult.fromFuture(Future{ Thread.sleep(2000); s }).attemptRunFor(_.getMessage, 1.millis) must_=== Fail("Futures timed out after [1 millisecond]")
+    }
+  }
+
+  "StaticFunctions" >> {
+    "fromResult" >> {
+      "should create an AsyncResult of the same underlying types" >> prop { r: Result[Int, Int] =>
+        attempt(AsyncResult.fromResult(r)) must_=== r
+      }
+    }
+
+    "fromFuture" >> {
+      "should create an Ok with the underlying future type" >> prop { n: Int =>
+        attempt(AsyncResult.fromFuture(Future(n))) must_=== Ok(n)
+      }
+    }
+
+    "fail" >> {
+      "should create a Fail" >> prop { n: Int =>
+        attempt(AsyncResult.fail(n)) must_=== Fail(n)
+      }
+    }
+
+    "ok" >> {
+      "should create an Ok" >> prop { n: Int =>
+        attempt(AsyncResult.ok(n)) must_=== Ok(n)
+      }
+    }
+
+    "attempt" >> {
+      "should catch any NonFatal exception and return it as a Fail" >> prop { e: Exception =>
+        def fails() = throw e
+        attempt(AsyncResult.attempt(fails())) must_=== Fail(e)
+      }
+      "should not catch a Fatal exception" >> {
+        def fails() = throw new StackOverflowError
+        AsyncResult.attempt(fails()) must throwA[StackOverflowError]
+      }
+      "should wrap the result in an Ok no exception is thrown" >> prop { n: Int =>
+        attempt(AsyncResult.attempt(f(n))) must_=== Ok(f(n))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Raising this more so we can have a bit of a discussion on this; whether it is sensible, and if so how the implementation should look.

This is very loosely modelled on scalaz's `Task`, however doesn't provide quite so much functionality. Really it's just a wrapper around `Future[Result[A, B]`. Most of the functionality delegates to the underlying `Result` which is inside of the future. It does provide a `flatMap` instance which allows it to be used in a for comprehension. 

Wanted to discuss if.
- The functionality makes sense
- If the functionality make sense, then do the names make sense?
- Does any more functionality need adding, like `onComplete`, `onSuccess` or `onFail`? Or whether we should just say that people should access that via the future in the `underlying` parameter (similar to the scalaz `Task` `get`?
