### PR TITLE
Additions to result

### DIFF
--- a/i18n/build.sbt
+++ b/i18n/build.sbt
@@ -12,5 +12,5 @@ scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/u
                         connection = "scm:git:git@github.com:albertpastrana/uscala.git"))
 
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "3.8.6" % "test"
+  Dependencies.Specs2Core
 )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,13 @@
+import sbt._
+
+object Dependencies {
+
+  object Versions {
+    val Specs2 = "4.0.3"
+  }
+
+  // Libraries
+  val Specs2Core = "org.specs2" %% "specs2-core" % Versions.Specs2
+  val Specs2ScalaCheck = "org.specs2" %% "specs2-scalacheck" % Versions.Specs2
+
+}

--- a/resources/build.sbt
+++ b/resources/build.sbt
@@ -13,5 +13,5 @@ scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/u
                         connection = "scm:git:git@github.com:albertpastrana/uscala.git"))
 
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "3.8.6" % "test"
+  Dependencies.Specs2Core
 )

--- a/result-async/build.sbt
+++ b/result-async/build.sbt
@@ -14,6 +14,6 @@ scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/u
                         connection = "scm:git:git@github.com:albertpastrana/uscala.git"))
 
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "3.8.6" % "test",
-  "org.specs2" %% "specs2-scalacheck" % "3.8.6" % "test"
+  Dependencies.Specs2Core,
+  Dependencies.Specs2ScalaCheck
 )

--- a/result-async/src/test/scala/uscala/concurrent/result/AsyncResultSpec.scala
+++ b/result-async/src/test/scala/uscala/concurrent/result/AsyncResultSpec.scala
@@ -6,7 +6,6 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.ScalaCheck
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
-import org.specs2.specification.mutable.ExecutionEnvironment
 import uscala.concurrent.result.AsyncResult.{attemptFuture, attemptSync, fromFuture, fromResult, fail => asyncFail, ok => asyncOk}
 import uscala.result.Result
 import uscala.result.Result.{Fail, Ok}
@@ -15,8 +14,7 @@ import uscala.result.specs2.ResultMatchers
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class AsyncResultSpec extends Specification with ScalaCheck with ResultMatchers
-                         with ExecutionEnvironment { def is(implicit ee: ExecutionEnv): Unit = {
+class AsyncResultSpec(implicit ee: ExecutionEnv) extends Specification with ScalaCheck with ResultMatchers {
 
   def resultGen: Gen[Result[Int, Int]] = Gen.posNum[Int].flatMap(i => Gen.oneOf(Ok[Int](i), Fail[Int](i)))
 
@@ -299,4 +297,4 @@ class AsyncResultSpec extends Specification with ScalaCheck with ResultMatchers
       }
     }
   }
-}}
+}

--- a/result-specs2/src/test/scala/uscala/result/specs2/ResultMatchersSpec.scala
+++ b/result-specs2/src/test/scala/uscala/result/specs2/ResultMatchersSpec.scala
@@ -1,10 +1,9 @@
 package uscala.result.specs2
 
 import org.specs2.Spec
-import org.specs2.matcher.{ResultMatchers => SResultMatchers}
 import uscala.result.Result._
 
-class ResultMatchersSpec extends Spec with SResultMatchers with ResultMatchers { def is = s2"""
+class ResultMatchersSpec extends Spec with ResultMatchers { def is = s2"""
  The ResultMatchers trait provides matchers to check Result instances
 
   beOk checks if an element is Ok(_)
@@ -14,7 +13,7 @@ class ResultMatchersSpec extends Spec with SResultMatchers with ResultMatchers {
   ${ Ok(1) must beOk(===(1)) }
   ${ Ok(Seq(1)) must beOk(===(Seq(1))) }
   ${ Ok(1) must beOk.like { case i => i must be_>(0) } }
-  ${ (Ok(1) must beOk.like { case i => i must be_<(0) }) returns "'Ok(1)' is Ok but 1 is not less than 0" }
+  ${ (Ok(1) must beOk.like { case i => i must be_<(0) }) returns "1 is not less than 0" }
   beFail checks if an element is Fail(_)
   ${ Fail(1) must beFail(1) }
   ${ Fail(1) must beFail(===(1)) }

--- a/result/build.sbt
+++ b/result/build.sbt
@@ -13,6 +13,6 @@ scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/u
                         connection = "scm:git:git@github.com:albertpastrana/uscala.git"))
 
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "3.8.6" % "test",
-  "org.specs2" %% "specs2-scalacheck" % "3.8.6" % "test"
+  Dependencies.Specs2Core,
+  Dependencies.Specs2ScalaCheck
 )

--- a/result/src/main/scala/uscala/result/Result.scala
+++ b/result/src/main/scala/uscala/result/Result.scala
@@ -100,6 +100,10 @@ object Result extends ResultFunctions {
 
   import scala.language.higherKinds
 
+  implicit class OptionResult[E, A](opt: Option[Result[E, A]]) {
+    def sequence: Result[E, Option[A]] = opt.fold(Result.ok[E, Option[A]](Option.empty[A]))(_.map(Option.apply))
+  }
+
   implicit class TraversableResult[E, A, M[X] <: TraversableOnce[X]](xs: M[Result[E, A]]) {
     def sequence(implicit cbf: CanBuildFrom[M[Result[E, A]], A, M[A]]): Result[E, M[A]] =
       xs.foldLeft(Result.ok[E, scala.collection.mutable.Builder[A, M[A]]](cbf(xs))) { (fr, fa) =>

--- a/result/src/main/scala/uscala/result/Result.scala
+++ b/result/src/main/scala/uscala/result/Result.scala
@@ -52,6 +52,8 @@ sealed abstract class Result[+A, +B] extends Product with Serializable {
     x
   }
 
+  def bitap[U](sideEffect: => U): Result[A, B] = this.bimap(a => { sideEffect; a }, b => { sideEffect; b })
+
   def swap: Result[B, A] = fold(Ok(_), Fail(_))
 
   def merge[AA >: A](implicit ev: B <:< AA): AA = fold(identity, ev.apply)

--- a/result/src/main/scala/uscala/result/Result.scala
+++ b/result/src/main/scala/uscala/result/Result.scala
@@ -37,12 +37,11 @@ sealed abstract class Result[+A, +B] extends Product with Serializable {
     case Ok(b) => Ok(fb(b))
   }
 
-  def filter[AA >: A](predicate: (B) => Boolean, orFailWith: => AA): Result[AA, B] =
-    this match {
-      case fail @ Result.Fail(_) => fail
-      case ok @ Result.Ok(b) if predicate(b) => ok
-      case _ => Fail(orFailWith)
-    }
+  def filter[AA >: A](predicate: (B) => Boolean, orFailWith: => AA): Result[AA, B] = this match {
+    case fail @ Result.Fail(_) => fail
+    case ok @ Result.Ok(b) if predicate(b) => ok
+    case _ => Fail(orFailWith)
+  }
 
   def filterNot[AA >: A](predicate: (B) => Boolean, orFailWith: => AA): Result[AA, B] =
     filter(!predicate(_), orFailWith)

--- a/result/src/main/scala/uscala/result/Result.scala
+++ b/result/src/main/scala/uscala/result/Result.scala
@@ -114,6 +114,16 @@ object Result extends ResultFunctions {
           a <- fa
         } yield r += a
       }.map(_.result())
+
+    def split(implicit bfe : CanBuildFrom[Nothing, E, M[E]], bfa : CanBuildFrom[Nothing, A, M[A]]): (M[E], M[A]) = {
+      val be = bfe()
+      val ba = bfa()
+      xs.foreach {
+        case Ok(v) => ba += v
+        case Fail(e) => be += e
+      }
+      (be.result, ba.result)
+    }
   }
 
   /**

--- a/result/src/main/scala/uscala/result/Result.scala
+++ b/result/src/main/scala/uscala/result/Result.scala
@@ -74,6 +74,8 @@ sealed abstract class Result[+A, +B] extends Product with Serializable {
     case _ => this
   }
 
+  def flatten[AA >: A, BB](implicit ev: B <:< Result[AA, BB]): Result[AA, BB] = this.flatMap(b => identity(ev(b)))
+
   def toEither: Either[A, B] = fold(Left(_), Right(_))
 
   def toOption: Option[B] = fold(_ => None, Some(_))

--- a/result/src/test/scala/uscala/result/ResultSpec.scala
+++ b/result/src/test/scala/uscala/result/ResultSpec.scala
@@ -284,15 +284,29 @@ class ResultSpec extends Specification with ScalaCheck {
     }
   }
 
-  "sequence for traversables" >> {
-    "should transform a Seq(Fail) into a Fail" >> prop { xs: Seq[Int] => xs.nonEmpty ==>
-      (xs.map(Result.fail).sequence must_=== Fail(xs.head))
+  "ops on traversables" >> {
+    "split" >> {
+      "should split a Seq[Result[E, A]] into a (Seq[E], Seq[A]) " >> prop { xs: Seq[Int] => xs.nonEmpty ==> {
+        val (fails, oks) = xs.map(x => if (x < 0) Fail(x) else Ok(x)).split
+        fails must contain(be_<(0)).foreach
+        oks must contain(be_>=(0)).foreach
+      }}
+      "should split an empty Seq into a (Seq.empty, Seq.empty)" >> {
+        val (fails, oks) = Seq.empty[Result[Int, String]].split
+        fails must_=== Seq.empty[Int]
+        oks must_=== Seq.empty[String]
+      }
     }
-    "should transform a Seq(Ok) into an Ok(Seq)" >> prop { xs: Seq[Int] => xs.nonEmpty ==>
-      (xs.map(Result.ok).sequence must_=== Ok(xs))
-    }
-    "should transform an empty Seq into an Ok(Seq.empty)" >> {
-      Seq.empty[Result[Int, String]].sequence must_=== Ok(Seq.empty[String])
+    "sequence" >> {
+      "should transform a Seq(Fail) into a Fail" >> prop { xs: Seq[Int] => xs.nonEmpty ==>
+        (xs.map(Result.fail).sequence must_=== Fail(xs.head))
+      }
+      "should transform a Seq(Ok) into an Ok(Seq)" >> prop { xs: Seq[Int] => xs.nonEmpty ==>
+        (xs.map(Result.ok).sequence must_=== Ok(xs))
+      }
+      "should transform an empty Seq into an Ok(Seq.empty)" >> {
+        Seq.empty[Result[Int, String]].sequence must_=== Ok(Seq.empty[String])
+      }
     }
   }
 

--- a/result/src/test/scala/uscala/result/ResultSpec.scala
+++ b/result/src/test/scala/uscala/result/ResultSpec.scala
@@ -260,6 +260,18 @@ class ResultSpec extends Specification with ScalaCheck {
     }
   }
 
+  "sequence for options" >> {
+    "should transform a Some(Fail) into a Fail" >> prop { x: Int =>
+      Some(Fail(x)).sequence must_=== Fail(x)
+    }
+    "should transform a Some(Ok) into an Ok(Some)" >> prop { x: Int =>
+      Some(Ok(x)).sequence must_=== Ok(Some(x))
+    }
+    "should transform None into an Ok(None)" >> {
+      Option.empty[Result[Int, String]].sequence must_=== Ok(None)
+    }
+  }
+
   "sequence for traversables" >> {
     "should transform a Seq(Fail) into a Fail" >> prop { xs: Seq[Int] => xs.nonEmpty ==>
       (xs.map(Result.fail).sequence must_=== Fail(xs.head))

--- a/result/src/test/scala/uscala/result/ResultSpec.scala
+++ b/result/src/test/scala/uscala/result/ResultSpec.scala
@@ -106,19 +106,33 @@ class ResultSpec extends Specification with ScalaCheck {
   "tap" >> {
     "should not execute the given f if Fail" >> prop { n: Int =>
       var executed = false
-      Fail(n).tap { _ => executed = true }
+      Fail(n).tap(_ => executed = true)
       executed must beFalse
     }
 
     "should execute the given f if Ok, passing the Ok value" >> prop { n: Int =>
       var received: Option[Int] = None
-      Ok(n).tap { x => received = Some(x) }
+      Ok(n).tap(x => received = Some(x))
       received must beSome(n)
     }
 
     "should execute the given f if Ok, leaving the result untouched" >> prop { n: Int =>
       var executed = false
-      Ok(n).tap { _ => executed = true } must_=== Ok(n)
+      Ok(n).tap(_ => executed = true) must_=== Ok(n)
+      executed must beTrue
+    }
+  }
+
+  "bitap" >> {
+    "should execute the given effect if Fail, leaving the result untouched" >> prop { n: Int =>
+      var executed = false
+      Fail(n).bitap { executed = true } must_=== Fail(n)
+      executed must beTrue
+    }
+
+    "should execute the given effect if Ok, leaving the result untouched" >> prop { n: Int =>
+      var executed = false
+      Ok(n).bitap { executed = true } must_=== Ok(n)
       executed must beTrue
     }
   }

--- a/result/src/test/scala/uscala/result/ResultSpec.scala
+++ b/result/src/test/scala/uscala/result/ResultSpec.scala
@@ -206,6 +206,18 @@ class ResultSpec extends Specification with ScalaCheck {
     }
   }
 
+  "flatten" >> {
+    "should transform a Ok(Ok(x)) into a Ok(x)" >> prop { n: Int =>
+      Ok(Ok(n)).flatten.toEither must beRight(n)
+    }
+    "should transform a Ok(Fail(x)) into a Fail(x)" >> prop { n: Int =>
+      Ok(Fail(n)).flatten.toEither must beLeft(n)
+    }
+    "should transform a Fail(x) into a Fail(x)" >> prop { n: Int =>
+      Fail(n).flatten.toEither must beLeft(n)
+    }
+  }
+
   "toEither" >> {
     "should put the Fail value on the left" >> prop { n: Int =>
       Fail(n).toEither must beLeft(n)

--- a/result/src/test/scala/uscala/result/ResultSpec.scala
+++ b/result/src/test/scala/uscala/result/ResultSpec.scala
@@ -1,7 +1,5 @@
 package uscala.result
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 import uscala.result.Result.{TraversableResult, Fail, Ok}
@@ -10,9 +8,9 @@ import scala.util.{Failure, Success}
 
 class ResultSpec extends Specification with ScalaCheck {
 
-  def f(n: Int) = n + 1
-  def fa(n: Int) = f(n)
-  def fb(n: Int) = n + 2
+  private def f(n: Int) = n + 1
+  private def fa(n: Int) = f(n)
+  private def fb(n: Int) = n + 2
 
   "fold" >> {
     "should apply fa if the result is Fail" >> prop { n: Int =>
@@ -157,16 +155,14 @@ class ResultSpec extends Specification with ScalaCheck {
 
   "foreach" >> {
     "should not apply f if it's a Fail" >> prop { n: Int =>
-      val effect = new AtomicBoolean(false)
-      def sideEffect(i: Int) = effect.set(true)
-      Fail(n).foreach(sideEffect)
-      effect.get must beFalse
+      var executed = false
+      Fail(n).foreach(_ => executed = true)
+      executed must beFalse
     }
     "should apply f if it's an Ok" >> prop { n: Int =>
-      val effect = new AtomicBoolean(false)
-      def sideEffect(i: Int) = effect.set(true)
-      Ok(n).foreach(sideEffect)
-      effect.get must beTrue
+      var executed = false
+      Ok(n).foreach(_ => executed = true)
+      executed must beTrue
     }
   }
 

--- a/retry/build.sbt
+++ b/retry/build.sbt
@@ -13,6 +13,6 @@ scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/u
                         connection = "scm:git:git@github.com:albertpastrana/uscala.git"))
 
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "3.8.6" % "test",
-  "org.specs2" %% "specs2-scalacheck" % "3.8.6" % "test"
+  Dependencies.Specs2Core,
+  Dependencies.Specs2ScalaCheck
 )

--- a/timeout/build.sbt
+++ b/timeout/build.sbt
@@ -13,5 +13,5 @@ scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/u
                         connection = "scm:git:git@github.com:albertpastrana/uscala.git"))
 
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "3.8.6" % "test"
+  Dependencies.Specs2Core
 )

--- a/url/build.sbt
+++ b/url/build.sbt
@@ -13,6 +13,6 @@ scmInfo := Some(ScmInfo(browseUrl = new URL("https://github.com/albertpastrana/u
                         connection = "scm:git:git@github.com:albertpastrana/uscala.git"))
 
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "3.8.6" % "test",
-  "org.specs2" %% "specs2-scalacheck" % "3.8.6" % "test"
+  Dependencies.Specs2Core,
+  Dependencies.Specs2ScalaCheck
 )


### PR DESCRIPTION
Adds the following:
`sequence` to `Option[Result[A, B]]`
`flatten` to `Result`
`split` to `TraversableOnce[Result]`
`bitap` to `Result`