### PR TITLE
Fixes asString when query has 1 param with no value

### DIFF
--- a/retry/src/test/scala/uscala/util/RetrySpec.scala
+++ b/retry/src/test/scala/uscala/util/RetrySpec.scala
@@ -30,14 +30,14 @@ class RetrySpec(implicit ee: ExecutionEnv) extends Specification with ScalaCheck
   private val exponential = List(
     (1, 0.25.seconds, 0.75.seconds),
     (2, 0.375.seconds, 1.125.seconds),
-    (3, 0.562.seconds, 1.687.seconds),
-    (4, 0.8435.seconds, 2.53.seconds),
-    (5, 1.265.seconds, 3.795.seconds),
-    (6, 1.897.seconds, 5.692.seconds),
-    (7, 2.846.seconds, 8.538.seconds),
-    (8, 4.269.seconds, 12.807.seconds),
-    (9, 6.403.seconds, 19.210.seconds),
-    (10, 9.605.seconds, 28.815.seconds)
+    (3, 0.561.seconds, 1.688.seconds),
+    (4, 0.843.seconds, 2.532.seconds),
+    (5, 1.265.seconds, 3.797.seconds),
+    (6, 1.898.seconds, 5.696.seconds),
+    (7, 2.847.seconds, 8.543.seconds),
+    (8, 4.271.seconds, 12.814.seconds),
+    (9, 6.407.seconds, 19.221.seconds),
+    (10, 9.610.seconds, 28.833.seconds)
   )
   private def arbExpGenerator = Gen.oneOf(exponential)
 

--- a/url/src/test/scala/uscala/net/QuerySpec.scala
+++ b/url/src/test/scala/uscala/net/QuerySpec.scala
@@ -7,9 +7,12 @@ import org.specs2.specification.core.Fragment
 class QuerySpec extends Specification with ScalaCheck with TestQueries {
 
   "apply(String)" >> {
-    "when the query is null" >> {
-      "should return an empty Query" >> {
+    "should return an empty Query" >> {
+      "when the query is null" >> {
         Query(null) must beASuccessfulTry.which(_.hasQuery must_=== false)
+      }
+      "when the query is empty" >> {
+        Query("") must beASuccessfulTry.which(_.hasQuery must_=== false)
       }
     }
 
@@ -24,6 +27,18 @@ class QuerySpec extends Specification with ScalaCheck with TestQueries {
     }
   }
 
+  "asString" >> {
+    "should return empty string if it's an empty query" >> {
+      Query("").map(_.asString) must beASuccessfulTry("")
+    }
+    "should add the ? at the beginning of the query" >> {
+      Query("key=value").map(_.asString) must beASuccessfulTry("?key=value")
+    }
+    "should return only the key if there is no value" >> {
+      Query("key=").map(_.asString) must beASuccessfulTry("?key")
+    }
+  }
+
   "Empty" >> {
     "hasQuery should always return false" >> {
       Empty.hasQuery must_== false
@@ -33,6 +48,9 @@ class QuerySpec extends Specification with ScalaCheck with TestQueries {
     }
     "getOrElse should always return the default value" >> {
       Empty.getOrElse("a", List("b")) must_=== List("b")
+    }
+    "asString should return an empty string" >> {
+      Empty.asString must_=== ""
     }
   }
 
@@ -62,15 +80,15 @@ class QuerySpec extends Specification with ScalaCheck with TestQueries {
 }
 
 trait TestQueries {
-  val testQueries = List(
-    "" -> Map.empty,
+  val testQueries: List[(String, Map[String, List[String]])] = List(
     "q" -> Map("q" -> Nil),
     "q=" -> Map("q" -> Nil),
     "k:ey=a=a" -> Map("k:ey" -> List("a=a")),
     "k:ey=a?a" -> Map("k:ey" -> List("a?a")),
     "k=a&k=b&k=c" -> Map("k" -> List("a", "b", "c")),
     "foo=bar&key=value" -> Map("foo" -> List("bar"), "key" -> List("value")),
-    "foo=bar&encoded=%2F-(4)+%26+a" -> Map("foo" -> List("bar"), "encoded" -> List("/-(4) & a"))
+    "foo=bar&encoded=%2F-(4)+%26+a" -> Map("foo" -> List("bar"), "encoded" -> List("/-(4) & a")),
+    "%3Cmy_tag_2f0e5c3f94df95106fbdd455f9abb89640/%3E=" -> Map("%3Cmy_tag_2f0e5c3f94df95106fbdd455f9abb89640/%3E" -> Nil)
   )
 
 }


### PR DESCRIPTION
When there was a key with no values in the query string,
there was a implicit conversion from string to list that
made the code compile but that messed up with the params.

That way, this query string `?hello` would be translated
into `?h&e&l&l&o`.

Signed-off-by: Albert Pastrana <albert.pastrana@gmail.com>