### PR TITLE
 Add `sequence` to go from `Result` of `Option` to `Option` of `Result`.

### DIFF
--- a/result/src/main/scala/uscala/result/Result.scala
+++ b/result/src/main/scala/uscala/result/Result.scala
@@ -119,6 +119,14 @@ object Result extends ResultFunctions with ResultBuildFromImplicits {
     def toResult: Result[Throwable, A] = Result.fromTry(t)
   }
 
+  implicit class ResultOption[E, A](result: Result[E, Option[A]]) {
+    def sequence: Option[Result[E, A]] = result match {
+      case Ok(Some(value)) => Some(Ok(value))
+      case Ok(None) => None
+      case fail @ Fail(_) => Some(fail)
+    }
+  }
+
   implicit class OptionResult[E, A](opt: Option[Result[E, A]]) {
     def sequence: Result[E, Option[A]] = opt.fold(Result.ok[E, Option[A]](Option.empty[A]))(_.map(Option.apply))
   }
@@ -134,7 +142,6 @@ object Result extends ResultFunctions with ResultBuildFromImplicits {
     def orIfTrue[C >: A](failWith: => C): Result[C, Boolean] =
       result.filterNot(identity, failWith)
   }
-
 }
 
 trait ResultFunctions {

--- a/result/src/test/scala/uscala/result/ResultSpec.scala
+++ b/result/src/test/scala/uscala/result/ResultSpec.scala
@@ -347,7 +347,19 @@ class ResultSpec extends Specification with ScalaCheck {
     }
   }
 
-  "sequence for options" >> {
+  "sequence for results of options" >> {
+    "should transform a Fail into a Some(Fail)" >> prop { x: Int =>
+      Result.fail[Int, Option[Int]](x).sequence must beSome(Result.fail[Int, Int](x))
+    }
+    "should transform a Ok(None) into a None" >> {
+      Ok(None).sequence must beNone
+    }
+    "should transform Ok(Some) into an Some(Ok)" >> prop { x: Int =>
+      Result.ok[Int, Option[Int]](Some(x)).sequence must beSome(Result.ok[Int, Int](x))
+    }
+  }
+
+  "sequence for options of results" >> {
     "should transform a Some(Fail) into a Fail" >> prop { x: Int =>
       Some(Fail(x)).sequence must_=== Fail(x)
     }


### PR DESCRIPTION
Useful method when you need to flip between them - we already have
`sequence` for `Option` of `Result` so now you can go both ways!